### PR TITLE
Removed "ensure" parameter from concat::framents

### DIFF
--- a/manifests/server/common.pp
+++ b/manifests/server/common.pp
@@ -45,7 +45,6 @@ class nfs::server::common {
 
         # Header of the exports file
         concat::fragment { "${nfs::params::exportsfile}_header":
-            ensure  => $nfs::server::ensure,
             target  => $nfs::params::exportsfile,
             content => template('nfs/exports_header.erb'),
             order   => 01,

--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -98,7 +98,6 @@ define nfs::server::export(
 
     if ($ensure == 'present') {
         concat::fragment { "${nfs::params::exportsfile}_${dirname}":
-            ensure => $ensure,
             target => $nfs::params::exportsfile,
             order  => $order,
             notify => Service['nfs-server'],


### PR DESCRIPTION
As this parameter war deprecated in concat::fragment 2.0.0 and remove in
concat::fragment 4.0.0.
See also https://tickets.puppetlabs.com/browse/MODULES-3753